### PR TITLE
Choco v2.1.0

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,14 +1,16 @@
 # syntax=docker/dockerfile:1
 
-ARG CHOCOLATEY_VERSION="1.3.1"
+ARG CHOCOLATEY_VERSION="2.1.0"
 ARG MONO_VERSION="6.12"
 ARG ALPINE_VERSION="3.17"
 
 FROM --platform=$BUILDPLATFORM alpine:${ALPINE_VERSION} as src
-RUN apk add --no-cache git
+RUN apk add --no-cache git patch
 WORKDIR /src
 ARG CHOCOLATEY_VERSION
 RUN git clone --branch ${CHOCOLATEY_VERSION} "https://github.com/chocolatey/choco.git" .
+COPY GitVersion.patch .
+RUN patch -u GitVersion.yml -i GitVersion.patch
 
 FROM mono:${MONO_VERSION} as builder
 ARG DEBIAN_FRONTEND=noninteractive

--- a/image/GitVersion.patch
+++ b/image/GitVersion.patch
@@ -1,0 +1,11 @@
+--- GitVersion.origin	2023-06-30 10:52:08.017731018 -0400
++++ GitVersion.yml	2023-06-30 10:49:41.978803029 -0400
+@@ -1 +1,8 @@
+ next-version: 2.0.0
++branches:
++  master:
++    regex: main
++    mode: ContinuousDeployment
++  feature: {}
++ignore:
++  sha: []


### PR DESCRIPTION
Bumped version of Chocolatey to 2.1.0.

While building Chocolatey from the source Git repo, I got the following error message:
`System.InvalidOperationException: Gitversion could not determine which branch to treat as the development branch (default is 'develop') nor release-able branch (default is 'main' or 'master'), either locally or remotely. Ensure the local clone and checkout match the requirements or considering using 'GitVersion Dynamic Repositories'`

Seems there was some missing config in the GitVersion.yml file so I created a simple patch.